### PR TITLE
ci/cd for pip package

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,89 @@
+name: Publish Python Package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'     # Production releases (PyPI)
+      - 'v*.*.*-rc*' # Release candidates (TestPyPI)
+      - 'v*.*.*-beta*' # Beta versions (TestPyPI)
+      - 'v*.*.*-alpha*' # Alpha versions (TestPyPI)
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+    
+    - name: Build package
+      run: |
+        uv build
+        echo "Build successful"
+
+    - name: Test package
+      run: |
+        uv run pytest
+
+    - name: Store built package
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+  
+  publish-test-pypi:
+    needs: build-and-test
+    # Only run for pre-release tags (contains '-')
+    if: contains(github.ref, '-')
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/${{ github.event.repository.name }}
+    permissions:
+      id-token: write  # For trusted publishing
+    
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+
+  publish-pypi:
+    needs: build-and-test
+    # Only run for full release tags (no '-' character)
+    if: ${{ !contains(github.ref, '-') }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/${{ github.event.repository.name }}
+    permissions:
+      id-token: write  # For trusted publishing
+    
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+    

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -34,7 +34,7 @@ jobs:
         uv run pytest
 
     - name: Store built package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/
@@ -52,7 +52,7 @@ jobs:
     
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -77,7 +77,7 @@ jobs:
     
     steps:
       - name: Download built package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to the Compliant LLM project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial project structure
+- Core functionality for testing AI system prompts against various attack vectors
+- CLI commands for running tests and generating reports
+- Web UI for interactive prompt testing
+- Docker support for containerized deployment
+
+### Changed
+- Migrated from pyenv to uv for Python environment and package management
+- Renamed project from "Prompt Secure" to "Compliant LLM"
+- Updated documentation to reflect new project name and structure
+
+## [0.1.0] - 2025-05-20
+
+### Added
+- First public release
+- Basic prompt testing functionality
+- Command-line interface
+- Web UI dashboard
+- Documentation
+
+[Unreleased]: https://github.com/fiddlecube/compliant-llm/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/fiddlecube/compliant-llm/releases/tag/v0.1.0

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,66 @@
+# Release Checklist for Compliant LLM
+
+This checklist helps ensure a smooth release process for new versions of the Compliant LLM package.
+
+## Before Release
+
+### Code Preparation
+- [ ] Update version number in `pyproject.toml`
+- [ ] Update `CHANGELOG.md` with all notable changes
+- [ ] Ensure all tests pass locally: `pytest`
+- [ ] Check code quality with linters: `flake8`, `black`, `mypy`
+- [ ] Verify all documentation is up to date
+- [ ] Make sure all CI checks pass on the main branch
+
+### Package Testing
+- [ ] Build the package locally:
+  ```bash
+  uv pip install build
+  python -m build
+  ```
+- [ ] Test installation from local build:
+  ```bash
+  uv pip install dist/compliant-llm-X.Y.Z-py3-none-any.whl
+  ```
+- [ ] Verify the installed package works as expected
+
+## Creating the Release
+
+### Git Operations
+- [ ] Commit all changes: `git commit -m "Prepare release vX.Y.Z"`
+- [ ] Tag the release: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
+- [ ] Push changes and tag: `git push origin main && git push origin vX.Y.Z`
+
+### GitHub Release
+- [ ] Go to GitHub Releases page
+- [ ] Create a new release using the tag
+- [ ] Copy relevant section from CHANGELOG.md to the release notes
+- [ ] Mark as pre-release if applicable
+- [ ] Publish release (this will trigger the GitHub Actions workflow)
+
+### Verify Publication
+- [ ] Check GitHub Actions workflow completed successfully
+- [ ] Verify package is available on TestPyPI (for pre-releases)
+- [ ] Verify package is available on PyPI (for full releases)
+- [ ] Test installation from PyPI:
+  ```bash
+  uv pip install compliant-llm==X.Y.Z
+  ```
+
+## After Release
+
+- [ ] Update version in `pyproject.toml` to next development version (X.Y.Z-dev)
+- [ ] Announce the release to relevant channels (if applicable)
+- [ ] Close related issues and milestones in GitHub
+- [ ] Review and address any feedback from early adopters
+
+## PyPI Secrets Setup (First-time only)
+
+To enable automated publishing to PyPI, add these secrets to your GitHub repository:
+
+1. Go to your GitHub repository → Settings → Secrets and variables → Actions
+2. Add the following secrets:
+   - `PYPI_USERNAME`: Your PyPI username
+   - `PYPI_PASSWORD`: Your PyPI password or token (preferred)
+   - `TEST_PYPI_USERNAME`: Your TestPyPI username
+   - `TEST_PYPI_PASSWORD`: Your TestPyPI password or token (preferred)


### PR DESCRIPTION
- add changelog
- release checklist

adds a github action to publish the release candidates to pypi and pre-release candidates to test.pypi

Pre-release candidates are in the format `v*.*.*-alpha1`, `v*.*.*-beta1`, or `v*.*.*-rc1`.
Release candidates are in the format `v*.*.*`

update publish action to support alpha, beta releases, and release candidates these releases will be published to test pypi
then the release will be published to a release branch and released to pypi