### PR TITLE
replace docs path with absolute url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Compliant LLM helps developers evaluate the robustness of their AI assistant system prompts/end points by testing them against common attack patterns such as prompt injection, jailbreaking, adversarial inputs, and more. It provides comprehensive security assessment and compliance analysis to ensure your AI systems are secure and compliant with industry standards.
 
-For detailed docs refer to [docs](./docs)
+For detailed docs refer to [docs](https://github.com/fiddlecube/compliant-llm/tree/main/docs)
 
 ## 🎯 Features
 


### PR DESCRIPTION
the relative url breaks in pypi
only absolute urls are allowed in the docs to ensure that links work across platforms