### PR TITLE
UI setup for getting provider from dashbaord

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ compliant-llm dashboard
 ## Roadmap
 
 - [ ] Full Application Pen Testing
-- [ ] Compliant MCP Servers
-- [ ] Multimodal Testing and Redteaming
-- [ ] CI/CD
+- [ ] Compliant and Logged MCP Servers
 - [ ] Support different Compliance Frameworks - HIPAA, GDPR, EU AI Act, etc.
+- [ ] Multimodal Testing
+- [ ] CI/CD
+- [ ] Access Control checks
 - [ ] Control Pane for different controls
 - [ ] Internal audits and documentation
 

--- a/core/config_manager/ui_adapter.py
+++ b/core/config_manager/ui_adapter.py
@@ -25,12 +25,12 @@ class UIConfigAdapter:
             "temperature": 0.7,        # Default temperature
             "max_tokens": 2000,        # Default max tokens
             "timeout": 30,             # Default timeout in seconds
-            "prompt": {"content": "You are a helpful assistant"},  # Default prompt
+            # "prompt": {"content": "You are a helpful assistant"},  # Default prompt
             "strategies": [],  # Default strategies,
             "output_path": {"path": str(DEFAULT_REPORTS_DIR), "filename": "report"},  # Default output path
         }
     
-    def run_test(self, prompt: str, strategies: List[str]) -> Dict[str, Any]:
+    def run_test(self, prompt: str, strategies: List[str], config: Dict[str, Any]) -> Dict[str, Any]:
         """
         Run tests with UI-specific configuration.
         

--- a/core/config_manager/ui_adapter.py
+++ b/core/config_manager/ui_adapter.py
@@ -21,12 +21,9 @@ class UIConfigAdapter:
         """
         self.config_manager = config_manager or ConfigManager()
         self.default_config = {
-            "provider": {"provider_name": "openai/gpt-4o"}, # Default provider
             "temperature": 0.7,        # Default temperature
             "max_tokens": 2000,        # Default max tokens
             "timeout": 30,             # Default timeout in seconds
-            # "prompt": {"content": "You are a helpful assistant"},  # Default prompt
-            "strategies": [],  # Default strategies,
             "output_path": {"path": str(DEFAULT_REPORTS_DIR), "filename": "report"},  # Default output path
         }
     
@@ -48,14 +45,15 @@ class UIConfigAdapter:
             raise ValueError("Prompt is required")
         if not strategies:
             raise ValueError("At least one strategy is required")
-            
+        print("=== ui config ===", config)
         # Create test configuration
         test_config = {
             "prompt": {"content": prompt},
             "strategies": strategies,
             "provider": {
-                "provider_name": self.default_config["provider"]["provider_name"],
-                "api_key": os.getenv(f"{self.default_config['provider']['provider_name'].upper()}_API_KEY", '')
+                "provider_name": config["provider_name"],
+                "model": config["model_name"],
+                "api_key": os.getenv(f"{config['provider_name'].upper()}_API_KEY", '')
             },
             "temperature": self.default_config["temperature"],
             "timeout": self.default_config["timeout"],
@@ -99,5 +97,6 @@ class UIConfigAdapter:
         """Get the current configuration."""
         config = self.default_config.copy()
         # Convert provider_name back to provider for backward compatibility
-        config["provider"] = config.pop("provider", "openai")
+        config["provider"] = config.pop("provider_name", "openai")
+        config["model"] = config.pop("model_name", "gpt-4o")
         return config

--- a/core/config_manager/ui_adapter.py
+++ b/core/config_manager/ui_adapter.py
@@ -2,6 +2,7 @@
 UI-specific configuration adapter for Compliant LLM.
 """
 import os
+from dotenv import load_dotenv, get_key
 from typing import Dict, List, Any, Optional
 from .config import ConfigManager, DEFAULT_REPORTS_DIR
 from core.runner import execute_prompt_tests_with_orchestrator
@@ -9,6 +10,8 @@ from rich.console import Console
 from rich.progress import (
     Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 )
+
+load_dotenv()
 class UIConfigAdapter:
     """Adapter for handling UI-specific configurations and test execution."""
     
@@ -45,15 +48,18 @@ class UIConfigAdapter:
             raise ValueError("Prompt is required")
         if not strategies:
             raise ValueError("At least one strategy is required")
-        print("=== ui config ===", config)
+        
         # Create test configuration
+        api_key_key = f"{config['provider_name'].upper()}_API_KEY"
+        api_key = os.getenv(api_key_key, 'n/a') or get_key(".env", api_key_key)
+
         test_config = {
             "prompt": {"content": prompt},
             "strategies": strategies,
             "provider": {
                 "provider_name": config["provider_name"],
-                "model": config["model_name"],
-                "api_key": os.getenv(f"{config['provider_name'].upper()}_API_KEY", '')
+                "model": config["model"],
+                "api_key": api_key
             },
             "temperature": self.default_config["temperature"],
             "timeout": self.default_config["timeout"],

--- a/ui/constants/provider.py
+++ b/ui/constants/provider.py
@@ -6,8 +6,8 @@ PROVIDERS = [
 ]
 
 PROVIDER_SETUP = [
-    {"name": "OpenAI", "value": "openai", "openai_api_key": ""},
-    {"name": "Anthropic", "value": "anthropic", "anthropic_api_key": ""},
-    {"name": "Gemini", "value": "gemini", "gemini_api_key": ""},
-    {"name": "Azure/OpenAI", "value": "azure_openai", "azure_openai_api_key": "", "azure_api_base": "", "azure_api_version": ""},
+    {"name": "OpenAI", "value": "openai", "openai_api_key": "","default_model": "gpt-4o"},
+    {"name": "Anthropic", "value": "anthropic", "anthropic_api_key": "","default_model": "claude-3-5-sonnet"},
+    {"name": "Gemini", "value": "gemini", "gemini_api_key": "","default_model": "gemini-2.0-flash-exp"},
+    {"name": "Azure/OpenAI", "value": "azure_openai", "azure_openai_api_key": "", "azure_api_base": "", "azure_api_version": "","default_model": "gpt-4o"},
 ]

--- a/ui/constants/provider.py
+++ b/ui/constants/provider.py
@@ -1,0 +1,13 @@
+PROVIDERS = [
+    {"name": "OpenAI", "value": "openai"},
+    {"name": "Anthropic", "value": "anthropic"},
+    {"name": "Google", "value": "google"},
+    {"name": "Azure/OpenAI", "value": "azure_openai"},
+]
+
+PROVIDER_SETUP = [
+    {"name": "OpenAI", "value": "openai", "openai_api_key": ""},
+    {"name": "Anthropic", "value": "anthropic", "anthropic_api_key": ""},
+    {"name": "Gemini", "value": "gemini", "gemini_api_key": ""},
+    {"name": "Azure/OpenAI", "value": "azure_openai", "azure_openai_api_key": "", "azure_api_base": "", "azure_api_version": ""},
+]

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -176,16 +176,17 @@ def create_app_ui():
         index=len(PROVIDER_SETUP) - 1
     )
     provider = next(p for p in PROVIDER_SETUP if p["name"] == provider_name)
-    model = st.text_input(
-        "Select Model", "gpt-4o"
-    )
+    
     has_all_keys = False
     # Form for entering keys
     with st.form("provider_form"):
         # Dynamically create input fields for the selected provider
         inputs = {}
+        model = st.text_input(
+                    "Enter Model", provider["default_model"]
+                )
         for key in provider:
-            if key in ("name", "value"):
+            if key in ("name", "value", "default_model"):
                 continue
             label = key.replace("_", " ").title()
             env_key = f"{key.upper()}"

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -159,122 +159,113 @@ def create_app_ui():
         open_dashboard_with_report(st.session_state['selected_report'])
         del st.session_state['selected_report']
     
-    # configuration payload
-    # config = {}
-    
-    # main content
-    st.header("Setup Configuration")
-    
-    # Configuration form
-    # Initialize session state for saved config
-    if 'saved_config' not in st.session_state:
-        st.session_state['saved_config'] = {}
 
-    # Select provider outside the form so it reruns on change
-    provider_name = st.selectbox(
-        "Select Provider", [p["name"] for p in PROVIDER_SETUP],
-        index=len(PROVIDER_SETUP) - 1
-    )
-    provider = next(p for p in PROVIDER_SETUP if p["name"] == provider_name)
-    
-    has_all_keys = False
     # Form for entering keys
-    with st.form("provider_form"):
-        # Dynamically create input fields for the selected provider
-        inputs = {}
-        model = st.text_input(
-                    "Enter Model", provider["default_model"]
-                )
-        for key in provider:
-            if key in ("name", "value", "default_model"):
-                continue
-            label = key.replace("_", " ").title()
-            env_key = f"{key.upper()}"
-            default_val = os.getenv(env_key, "") or get_key(".env", env_key)
-            if default_val is None:
-                has_all_keys = False
-            else:
-                has_all_keys = True
-            inputs[key] = st.text_input(label, value=default_val, type="password" if "API_KEY" in env_key else "default")
+    with st.expander("Setup Configuration", expanded=True):
+        has_all_keys = False
+        if 'saved_config' not in st.session_state:
+            st.session_state['saved_config'] = {}
 
-        submitted = st.form_submit_button("Save Config")
+        # Select provider outside the form so it reruns on change
+        provider_name = st.selectbox(
+            "Select Provider", [p["name"] for p in PROVIDER_SETUP],
+            index=len(PROVIDER_SETUP) - 1
+        )
+        provider = next(p for p in PROVIDER_SETUP if p["name"] == provider_name)
+        
+        with st.form("provider_form", border=False):
+            # Dynamically create input fields for the selected provider
+            inputs = {}
+            model = st.text_input(
+                        "Enter Model", provider["default_model"]
+                    )
+            for key in provider:
+                if key in ("name", "value", "default_model"):
+                    continue
+                label = key.replace("_", " ").title()
+                env_key = f"{key.upper()}"
+                default_val = os.getenv(env_key, "") or get_key(".env", env_key)
+                if default_val is None:
+                    has_all_keys = False
+                else:
+                    has_all_keys = True
+                inputs[key] = st.text_input(label, value=default_val, type="password" if "API_KEY" in env_key else "default")
 
-        if submitted:
-            if not provider_name:
-                st.error("Please select a provider")
-                return
-            if not model:
-                st.error("Please select a model")
-                return
-            
-            empty_fields = [key for key, value in inputs.items() if not value.strip()]
-            if empty_fields:
-                st.error(f"Please fill in all required fields: {', '.join(empty_fields)}")
-                return
-            
-            env_path = ".env"
-            if not os.path.exists(env_path):
-                open(env_path, "w").close()
+            submitted = st.form_submit_button("Save Config")
 
-            config = {'provider_name': provider['value'], 'model': model}
-            for field, val in inputs.items():
-                env_key = f"{field.upper()}"
-                set_key(env_path, env_key, val)
-                # Set in-process environment for immediate use
-                os.environ[env_key] = val
-                # st.success(f"Configuration for {provider_name} saved to .env and loaded into session")
-                config[field] = val
+            if submitted:
+                if not provider_name:
+                    st.error("Please select a provider")
+                    return
+                if not model:
+                    st.error("Please select a model")
+                    return
+                
+                empty_fields = [key for key, value in inputs.items() if not value.strip()]
+                if empty_fields:
+                    st.error(f"Please fill in all required fields: {', '.join(empty_fields)}")
+                    return
+                
+                env_path = ".env"
+                if not os.path.exists(env_path):
+                    open(env_path, "w").close()
 
-            st.session_state['saved_config'] = config
+                config = {'provider_name': provider['value'], 'model': model}
+                for field, val in inputs.items():
+                    env_key = f"{field.upper()}"
+                    set_key(env_path, env_key, val)
+                    # Set in-process environment for immediate use
+                    os.environ[env_key] = val
+                    # st.success(f"Configuration for {provider_name} saved to .env and loaded into session")
+                    config[field] = val
+
+                st.session_state['saved_config'] = config
     
+    # Form for running tests
+    with st.expander("Run New Test", expanded=True):
+        submit_button_disabled = True
+        provider_config = st.session_state['saved_config']
 
-    st.header("Run New Test")
-    submit_button_disabled = True
-    provider_config = st.session_state['saved_config']
-
-    if provider_config or has_all_keys:
-        submit_button_disabled = False
-    with st.form("test_form", clear_on_submit=True):
-        col1, col2 = st.columns([2, 1])
-        with col1:
+        if provider_config or has_all_keys:
+            submit_button_disabled = False
+        with st.form("test_form", clear_on_submit=True, border=False):
             prompt = st.text_area("Enter your prompt:", height=150, placeholder="Enter your system prompt here...")
-        with col2:
             st.write("### Select Testing Strategies")
             selected_strategies = st.multiselect("Choose strategies to test", get_available_strategies(), default=["prompt_injection", "jailbreak"])
-        submit_button = st.form_submit_button(label="Run Test", type="primary", disabled=submit_button_disabled)
+            submit_button = st.form_submit_button(label="Run Test", type="primary", disabled=submit_button_disabled)
 
-    if submit_button:
-        if not prompt.strip():
-            st.error("🚫 Please enter a prompt!")
-            st.stop()
-        if not selected_strategies:
-            st.error("🚫 Please select at least one testing strategy!")
-            st.stop()
+        if submit_button:
+            if not prompt.strip():
+                st.error("🚫 Please enter a prompt!")
+                st.stop()
+            if not selected_strategies:
+                st.error("🚫 Please select at least one testing strategy!")
+                st.stop()
 
-        with st.spinner("🔍 Running tests..."):
-            stdout, stderr = run_test(prompt, selected_strategies, provider_config)
-            reports = get_reports()
+            with st.spinner("🔍 Running tests..."):
+                stdout, stderr = run_test(prompt, selected_strategies, provider_config)
+                reports = get_reports()
 
-        st.subheader("✅ Test Results")
-        st.write("---")
+            st.subheader("✅ Test Results")
+            st.write("---")
 
-        if stdout:
-            try:
-                json_output = json.loads(stdout)
-                render_beautiful_json_output(json_output)
-            except json.JSONDecodeError:
-                st.warning("⚠️ Output is not valid JSON. Showing raw output instead:")
-                st.code(stdout, language="text")
-        else:
-            st.info("ℹ️ No test output received.")
+            if stdout:
+                try:
+                    json_output = json.loads(stdout)
+                    render_beautiful_json_output(json_output)
+                except json.JSONDecodeError:
+                    st.warning("⚠️ Output is not valid JSON. Showing raw output instead:")
+                    st.code(stdout, language="text")
+            else:
+                st.info("ℹ️ No test output received.")
 
-        if stderr:
-            st.error("❌ Error Output:")
-            st.code(stderr, language="bash")
+            if stderr:
+                st.error("❌ Error Output:")
+                st.code(stderr, language="bash")
 
-        if reports:
-            latest_report = reports[0]
-            open_dashboard_with_report(latest_report["path"])
+            if reports:
+                latest_report = reports[0]
+                open_dashboard_with_report(latest_report["path"])
 
 def main():
     create_app_ui()


### PR DESCRIPTION
**Description**

- UI setup for getting provider config from the dashboard
- tested attacks from ui, is working for open ai
- as provider changes, the inout fields for keys change. they are prepopulated if present in .env or osenv


**Screenshots/Results**

- Add a screenshot of the changes or code responses
<img width="1512" alt="Screenshot 2025-05-27 at 12 13 31 PM" src="https://github.com/user-attachments/assets/02f18399-cde4-4535-9770-72a362c11e6a" />


**Reference Links**

- Links to JIRA issue, links, Slack discussions, etc.

**Checklist**

This PR includes the following (tick all that apply):

- [ ] Tests added/updated for new/changed functionality
- [x] Bug Fix (explain the bug in the description)
- [ ] Refactoring or optimizations (no functional changes)
- [ ] Documentation updated (README, docstrings, etc.)
- [ ] Build or deployment related changes
- [ ] Dependency updates (requirements.txt/pyproject.toml)
- [ ] Setup change (update README/setup instructions if required)
- [ ] Code style checks passed (PEP8, flake8, black, etc.)
- [ ] Type hints added/updated (if applicable)
- [ ] Pre-commit hooks run (if configured)