### PR TITLE
change image to use absolute url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Compliant LLM](/docs/images/github.png)](https://github.com/fiddlecube/compliant-llm)
+[![Compliant LLM](https://github.com/fiddlecube/compliant-llm/blob/main/docs/images/github.png)](https://github.com/fiddlecube/compliant-llm)
 
 [![PyPI](https://img.shields.io/pypi/dm/compliant-llm?label=pypi%20compliant-llm)](https://pypi.org/project/compliant-llm/)
 [![Documentation](https://img.shields.io/badge/Documentation-Read-green?style=flat&logo=github)](https://github.com/fiddlecube/compliant-llm/tree/main/docs)


### PR DESCRIPTION
**Description**

- What is this PR about?
- Use absolute URL for top-level image

**Screenshots/Results**

Test PyPi doc broken Compliant LLM logo
![Screenshot 2025-05-27 at 4 59 24 PM](https://github.com/user-attachments/assets/c312c997-d4f4-4da7-b057-43651859bd0a)


**Reference Links**

- Links to JIRA issue, links, Slack discussions, etc.

**Checklist**

This PR includes the following (tick all that apply):

- [ ] Tests added/updated for new/changed functionality
- [ ] Bug Fix (explain the bug in the description)
- [ ] Refactoring or optimizations (no functional changes)
- [x] Documentation updated (README, docstrings, etc.)
- [ ] Build or deployment related changes
- [ ] Dependency updates (requirements.txt/pyproject.toml)
- [ ] Setup change (update README/setup instructions if required)
- [ ] Code style checks passed (PEP8, flake8, black, etc.)
- [ ] Type hints added/updated (if applicable)
- [ ] Pre-commit hooks run (if configured)