### PR TITLE
fix README image in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Compliant LLM](https://github.com/fiddlecube/compliant-llm/blob/main/docs/images/github.png)](https://github.com/fiddlecube/compliant-llm)
+![Compliant LLM](https://github.com/fiddlecube/compliant-llm/blob/main/docs/images/github.png)(https://github.com/fiddlecube/compliant-llm)
 
 [![PyPI](https://img.shields.io/pypi/dm/compliant-llm?label=pypi%20compliant-llm)](https://pypi.org/project/compliant-llm/)
 [![Documentation](https://img.shields.io/badge/Documentation-Read-green?style=flat&logo=github)](https://github.com/fiddlecube/compliant-llm/tree/main/docs)


### PR DESCRIPTION
**Description**

Due to an additional square braces, the top banner image is not rendering on pypi.

attempting to fix it by removing the square braces surrounding the image

- What is this PR about?

Fixes issue below
![Screenshot 2025-05-27 at 4 59 24 PM](https://github.com/user-attachments/assets/d204f58f-bd4d-46c6-89f8-1c78ecf817fd)


- Add a screenshot of the changes or code responses

**Reference Links**

- Links to JIRA issue, links, Slack discussions, etc.

**Checklist**

This PR includes the following (tick all that apply):

- [ ] Tests added/updated for new/changed functionality
- [ ] Bug Fix (explain the bug in the description)
- [ ] Refactoring or optimizations (no functional changes)
- [ ] Documentation updated (README, docstrings, etc.)
- [ ] Build or deployment related changes
- [ ] Dependency updates (requirements.txt/pyproject.toml)
- [ ] Setup change (update README/setup instructions if required)
- [ ] Code style checks passed (PEP8, flake8, black, etc.)
- [ ] Type hints added/updated (if applicable)
- [ ] Pre-commit hooks run (if configured)