### PR TITLE
bugfix: Reset to defaults after strategies are run

### DIFF
--- a/core/data_store/model_config_store.py
+++ b/core/data_store/model_config_store.py
@@ -17,7 +17,7 @@ def _get_table():
         _db_instance = TinyDB(CONFIG_DB_FILE)
     return _db_instance.table('model_config')
 
-def save_config(runner_config_data: Dict[str, Any], profile_name: str | None = None) -> None:
+def save_config(runner_config_data: Dict[str, Any], profile_name: Optional[str] = None) -> None:
     """Saves or updates a model configuration profile."""
     table = _get_table()
 

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -380,8 +380,7 @@ def create_app_ui():
         if submit_button:
             # Save form values to session state
             st.session_state.test_prompt = prompt
-            current_strategies = set(selected_strategies)
-            st.session_state.test_strategies = list(current_strategies)
+            st.session_state.test_strategies = selected_strategies
             
             if not prompt.strip():
                 st.error("🚫 Please enter a prompt!")
@@ -391,7 +390,10 @@ def create_app_ui():
                 st.stop()
 
             with st.spinner("🔍 Running tests..."):
-                output = adapter.run_test(provider_config["id"], prompt, st.session_state.test_strategies)
+                output = adapter.run_test(provider_config["id"], prompt, selected_strategies)
+                # resetting this to defaults after tests are run
+                st.session_state.test_prompt = ""
+                st.session_state.test_strategies = ["prompt_injection", "jailbreak"]
                 reports = get_reports()
 
             st.subheader("✅ Test Results")


### PR DESCRIPTION
**Description**

1. Reset to defaults once strategies are run | The default test_strategies were being used 
2. str | None is not working sometimes moved to Optional[str]



**Screenshots/Results**



**Reference Links**

- Links to JIRA issue, links, Slack discussions, etc.

**Checklist**

This PR includes the following (tick all that apply):

- [ ] Tests added/updated for new/changed functionality
- [x] Bug Fix (explain the bug in the description)
- [ ] Refactoring or optimizations (no functional changes)
- [ ] Documentation updated (README, docstrings, etc.)
- [ ] Build or deployment related changes
- [ ] Dependency updates (requirements.txt/pyproject.toml)
- [ ] Setup change (update README/setup instructions if required)
- [ ] Code style checks passed (PEP8, flake8, black, etc.)
- [ ] Type hints added/updated (if applicable)
- [ ] Pre-commit hooks run (if configured)